### PR TITLE
fix: quote bash variables to avoid word splitting

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,6 +2,6 @@
 
 set -ex
 
-source ${BASH_SOURCE%/*}/versions.sh
+source "${BASH_SOURCE%/*}"/versions.sh
 
-docker run -v $(pwd):/src emscripten/emsdk:${emscripten_version} bash -c 'scripts/install_deps.sh; scripts/build_clingo.sh'
+docker run -v "$(pwd)":/src emscripten/emsdk:${emscripten_version} bash -c 'scripts/install_deps.sh; scripts/build_clingo.sh'

--- a/scripts/build_clingo.sh
+++ b/scripts/build_clingo.sh
@@ -2,13 +2,13 @@
 
 set -ex
 
-source ${BASH_SOURCE%/*}/versions.sh
+source "${BASH_SOURCE%/*}"/versions.sh
 
 # Get number of processors.
 
 if [ "$(uname)" == "Darwin" ]; then
     procs=$(sysctl -n hw.physicalcpu) 
-elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+elif [ "$(expr substr "$(uname -s)" 1 5)" == "Linux" ]; then
     procs=$(nproc)
 else
    echo "Bad platform"
@@ -27,7 +27,7 @@ popd
 # Fetch and compile Clingo.
 
 clingo=clingo-${clingo_version}
-wget https://github.com/potassco/clingo/archive/v${clingo_version}.tar.gz -O clingo.tar.gz
+wget https://github.com/potassco/clingo/archive/v"${clingo_version}".tar.gz -O clingo.tar.gz
 tar -xf clingo.tar.gz
 
 root_dir=$(pwd)  # assumes that the script is run from the root
@@ -39,8 +39,8 @@ pushd build/web
 emcmake cmake \
         -DCLINGO_BUILD_WEB=On \
         -DCLINGO_BUILD_WITH_PYTHON=Off \
-        -DLUA_INCLUDE_DIR=${root_dir}/$lua/install/include \
-        -DLUA_LIBRARIES=${root_dir}/$lua/install/lib/liblua.a \
+        -DLUA_INCLUDE_DIR="${root_dir}"/"$lua"/install/include \
+        -DLUA_LIBRARIES="${root_dir}"/"$lua"/install/lib/liblua.a \
         -DCLINGO_BUILD_WITH_LUA=On \
         -DCLINGO_REQUIRE_LUA=On \
         -DCLINGO_BUILD_SHARED=Off \
@@ -53,8 +53,8 @@ emcmake cmake \
         ../..
 
 popd
-make -C build/web web -j $procs
+make -C build/web web -j "$procs"
 
 # Copy the results to root.
 popd
-cp $clingo/build/web/bin/clingo.* ./src/
+cp "$clingo"/build/web/bin/clingo.* ./src/


### PR DESCRIPTION
### Goals

- Fix the build script to generate a `dist` folder for the release

### Notes

- Due to the fact that variables were not quoted previously, the line responsible for copying the dist folder to the docker mounted folder got word splitted:

```
# Without quoting
cp clingo-5.5.2/build/web/bin/clingo.js clingo-5.5.2/build/web/bin/clingo.wasm ./src/
```

- Quoting the corresponding variable fixes this issue, after executing `yarn build:all`, the `dist` folder appears on my host

```
# With quoting
cp "clingo-5.5.2/build/web/bin/clingo.js clingo-5.5.2/build/web/bin/clingo.wasm" ./src/
```

Closes #224