### PR TITLE
feat: add restart method

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,7 @@ The Clingo worker can also be terminated and restarted with the following API. T
 ```html
 <script>
   async function restart() {
-    clingo.restart();  // terminate and restart the worker
-    await clingo.init("https://cdn.jsdelivr.net/npm/clingo-wasm@VERSION/dist/clingo.wasm")  // re-initialize Clingo
+    await clingo.restart("https://cdn.jsdelivr.net/npm/clingo-wasm@VERSION/dist/clingo.wasm")  // re-initialize Clingo
   }
   
   restart();

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 [![Build WASM](https://github.com/domoritz/clingo-wasm/actions/workflows/release.yml/badge.svg)](https://github.com/domoritz/clingo-wasm/actions/workflows/release.yml)
 
 [Clingo](https://github.com/potassco/clingo) compiled to [WebAssembly](https://webassembly.org/) with [Emscripten](https://kripken.github.io/emscripten-site/).
-Try it online at https://observablehq.com/@cmudig/clingo or https://domoritz.github.io/clingo-wasm.
+Try it online at <https://observablehq.com/@cmudig/clingo> or <https://domoritz.github.io/clingo-wasm>.
 
-This repo combines work from two previous repos: https://github.com/Aluriak/webclingo-example and https://github.com/domoritz/wasm-clingo.
+This repo combines work from two previous repos: <https://github.com/Aluriak/webclingo-example> and <https://github.com/domoritz/wasm-clingo>.
 
 ## Installation and Usage
 
@@ -44,6 +44,19 @@ We expose an UMD bundle that runs Clingo in a separate worker thread. Therefore,
   }
 
   main();
+</script>
+```
+
+The Clingo worker can also be terminated and restarted with the following API. This API is useful when the Clingo program takes much time and the user want to interrupt it. Moreover, please re-initialize the Clingo WASM after restarting the worker.
+
+```html
+<script>
+  async function restart() {
+    clingo.restart();  // terminate and restart the worker
+    await clingo.init("https://cdn.jsdelivr.net/npm/clingo-wasm@VERSION/dist/clingo.wasm")  // re-initialize Clingo
+  }
+  
+  restart();
 </script>
 ```
 

--- a/src/index.web.ts
+++ b/src/index.web.ts
@@ -35,9 +35,10 @@ export async function init(wasmUrl: string): Promise<void> {
   });
 }
 
-export function restart(): void {
+export async function restart(wasmUrl: string): Promise<void> {
   worker.terminate();
   worker = new Worker();
+  init(wasmUrl);
 }
 
 export default run;

--- a/src/index.web.ts
+++ b/src/index.web.ts
@@ -3,7 +3,7 @@ export type { ClingoResult } from "./run";
 import type { RunFunction } from "./run";
 import Worker, { Messages } from "./run.worker";
 
-const worker = new Worker();
+export const worker = new Worker();
 
 /**
  * @param program The logic program you wish to run.

--- a/src/index.web.ts
+++ b/src/index.web.ts
@@ -38,7 +38,7 @@ export async function init(wasmUrl: string): Promise<void> {
 export async function restart(wasmUrl: string): Promise<void> {
   worker.terminate();
   worker = new Worker();
-  init(wasmUrl);
+  await init(wasmUrl);
 }
 
 export default run;

--- a/src/index.web.ts
+++ b/src/index.web.ts
@@ -3,7 +3,7 @@ export type { ClingoResult } from "./run";
 import type { RunFunction } from "./run";
 import Worker, { Messages } from "./run.worker";
 
-export const worker = new Worker();
+let worker = new Worker();
 
 /**
  * @param program The logic program you wish to run.
@@ -33,6 +33,11 @@ export async function init(wasmUrl: string): Promise<void> {
     const message: Messages = { type: "init", wasmUrl };
     worker.postMessage(message);
   });
+}
+
+export function restart(): void {
+  worker.terminate();
+  worker = new Worker();
 }
 
 export default run;


### PR DESCRIPTION
This PR will resolve #409.

It just simply export the `worker` in the module, which means that you can get the worker with `clingo.worker` and achieves everything in #409.

However, this PR might not be a *perfect* solution, because the worker function needs to be imported twice (since the worker code is inlined into `clingo.web.js` by webpack, and the worker `clingo.web.worker.js` should also be included) if you want to achieve the target in issue #409. I am not very familiar with webpack/worker-loader, and I don't know how to "decouple" the base codes and the worker codes.
