### PR TITLE
Stream models while solving

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,27 @@ The Clingo worker can also be terminated and restarted with the following API. T
 </script>
 ```
 
+### Streaming Models
+
+To receive models as Clingo finds them instead of all at once at the end, pass a callback to `run`:
+
+```js
+await clingo.run("{a; b; c}.", 0, [], (model) => console.log(model.Value));
+```
+
+or use the `stream` async generator:
+
+```js
+for await (const model of clingo.stream("{a; b; c}.", 0)) {
+  console.log(model.Value);
+}
+```
+
+In the browser, models arrive while solving runs in the worker. In Node, solving blocks, so the callback fires during the run but the generator yields only once solving finishes.
+
 ### Parallel Solving
 
-The package ships two builds of Clingo: the default single-threaded one and one with thread support (`dist/clingo-mt.wasm`). The right build is picked automatically, and when threads are available you can use Clingo's parallel solving options:
+The package ships a second build of Clingo with thread support and picks it automatically when the environment allows. Where threads are available, Clingo's parallel solving options work:
 
 ```js
 if (clingo.supportsThreads()) {
@@ -71,12 +89,7 @@ if (clingo.supportsThreads()) {
 }
 ```
 
-Threads require `SharedArrayBuffer`:
-
-- In Node, this is always available (the thread pool needs `navigator.hardwareConcurrency`, so Node 21 or later).
-- In browsers, the page must be [cross-origin isolated](https://web.dev/articles/coop-coep): serve it with the `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp` headers. Pages without those headers automatically fall back to the single-threaded build.
-
-Pass at most `navigator.hardwareConcurrency` threads to `-t`; the preallocated worker pool has that size. When you pass a custom wasm URL to `clingo.init`, the single-threaded build is used since a single URL can only point at one of the two wasm files.
+Threads need `SharedArrayBuffer`: in Node it is always available (Node 21 or later), in browsers only on [cross-origin isolated](https://web.dev/articles/coop-coep) pages served with the COOP/COEP headers. Everywhere else the single-threaded build is used and `-t` reports an error. Use at most `navigator.hardwareConcurrency` threads, and note that passing a custom wasm URL to `init` selects the single-threaded build.
 
 ## Developers
 

--- a/examples/js/clingo-module.js
+++ b/examples/js/clingo-module.js
@@ -83,6 +83,7 @@ Clingo = {
     return function(text) {
       if (arguments.length > 1) text = Array.prototype.slice.call(arguments).join(' ');
       output += text + "\n";
+      updateOutput(); // show models as they are found
     };
   })(),
   printErr: function(text) {

--- a/src/index.node.ts
+++ b/src/index.node.ts
@@ -1,4 +1,13 @@
-import { init, Runner, ClingoResult, ClingoError, RunFunction } from "./run";
+import {
+  init,
+  Runner,
+  ClingoResult,
+  ClingoError,
+  RunFunction,
+  Witness,
+  OnModel,
+} from "./run";
+import { makeStream } from "./stream";
 import { supportsThreads } from "./threads";
 
 let runPromise: Promise<RunFunction> | undefined;
@@ -12,11 +21,21 @@ export async function run(
   return (await runPromise)(...args);
 }
 
+/**
+ * Runs like `run` but returns an async generator that yields each model and
+ * returns the final result. Since solving blocks in Node, the models are all
+ * yielded right after solving finishes; pass an onModel callback to `run` to
+ * observe them while solving.
+ */
+export const stream = makeStream(run);
+
 export {
   Runner,
   ClingoResult,
   ClingoError,
   RunFunction,
+  Witness,
+  OnModel,
   init,
   supportsThreads,
 };

--- a/src/index.web.ts
+++ b/src/index.web.ts
@@ -1,8 +1,9 @@
-export type { ClingoResult, ClingoError } from "./run";
+export type { ClingoResult, ClingoError, Witness, OnModel } from "./run";
 export { supportsThreads } from "./threads";
 
 import type { RunFunction } from "./run";
-import Worker, { Messages } from "./run.worker";
+import { makeStream } from "./stream";
+import Worker, { Messages, Replies } from "./run.worker";
 
 let worker = new Worker();
 
@@ -10,26 +11,42 @@ let worker = new Worker();
  * @param program The logic program you wish to run.
  * @param models The number of models you wish returned. Defaults to 1.
  * @param options You pass in a string enumerating command line options for Clingo.
+ * @param onModel Called with each model as clingo finds it.
  *
  * These are described in detail in the Potassco guide: https://github.com/potassco/guide/releases/
  */
 export async function run(
   ...args: Parameters<RunFunction>
 ): Promise<ReturnType<RunFunction>> {
+  const [program, models, options, onModel] = args;
   return new Promise((resolve, reject) => {
     worker.onmessage = (event: MessageEvent) => {
-      const { data: result } = event;
-      resolve(result);
+      const reply: Replies = event.data;
+      if (reply.type === "model") {
+        onModel?.(reply.model);
+      } else {
+        resolve(reply.result!);
+      }
     };
-    const message: Messages = { type: "run", args };
+    const message: Messages = {
+      type: "run",
+      args: [program, models, options],
+      stream: !!onModel,
+    };
     worker.postMessage(message);
   });
 }
 
+/**
+ * Runs like `run` but returns an async generator that yields each model as
+ * clingo finds it and returns the final result.
+ */
+export const stream = makeStream(run);
+
 export async function init(wasmUrl?: string): Promise<void> {
   return new Promise((resolve, reject) => {
     worker.onmessage = (event: MessageEvent) => {
-      resolve(event.data);
+      resolve(event.data.result);
     };
     const message: Messages = { type: "init", wasmUrl };
     worker.postMessage(message);

--- a/src/run.ts
+++ b/src/run.ts
@@ -3,19 +3,20 @@
 import { Module } from "./clingo.js";
 import { Module as ModuleMt } from "./clingo-mt.js";
 import { supportsThreads } from "./threads";
+import { Witness, WitnessParser } from "./witnesses";
 
 export { supportsThreads };
+export type { Witness };
+
+/** Called with each model as clingo finds it, while solving is running. */
+export type OnModel = (model: Witness) => void;
 
 export interface ClingoResult {
   Solver?: string;
   Calls: number;
 
   Call: {
-    Witnesses: {
-      Value: string[];
-      Costs?: number[];
-      Consequences?: any;
-    }[];
+    Witnesses: Witness[];
   }[];
 
   Models: {
@@ -58,6 +59,7 @@ export type ClingoParams = Partial<EmscriptenModule> & {
 export class Runner {
   private results: string[] = [];
   private errors: string[] = [];
+  private parser?: WitnessParser;
   private clingo!: ClingoModule;
 
   constructor(private extraParams: ClingoParams = {}) {}
@@ -69,7 +71,10 @@ export class Runner {
     if (!this.clingo) {
       const { singleThreaded, ...rest } = this.extraParams;
       const params: ClingoParams = {
-        print: (line) => this.results.push(line),
+        print: (line) => {
+          this.results.push(line);
+          this.parser?.feed(line);
+        },
         printErr: (line) => this.errors.push(line),
         ...rest,
       };
@@ -89,9 +94,15 @@ export class Runner {
   // instead of an exception propagating to JavaScript.
   private static ERROR_STATUS = new Set([33, 65, 128]);
 
-  run(program: string, models: number = 1, options: string[] = []) {
+  run(
+    program: string,
+    models: number = 1,
+    options: string[] = [],
+    onModel?: OnModel
+  ) {
     this.results = [];
     this.errors = [];
+    this.parser = onModel && new WitnessParser(onModel);
 
     try {
       const status = this.clingo.ccall(

--- a/src/run.ts
+++ b/src/run.ts
@@ -73,7 +73,13 @@ export class Runner {
       const params: ClingoParams = {
         print: (line) => {
           this.results.push(line);
-          this.parser?.feed(line);
+          try {
+            this.parser?.feed(line);
+          } catch (e) {
+            // a parser problem must only degrade streaming, never the run
+            this.parser = undefined;
+            console.warn("stopped streaming models:", e);
+          }
         },
         printErr: (line) => this.errors.push(line),
         ...rest,

--- a/src/run.ts
+++ b/src/run.ts
@@ -133,6 +133,11 @@ export class Runner {
 
 export type RunFunction = typeof Runner.prototype.run;
 
+/** The shape of the promise-based run functions exported by the entry points. */
+export type AsyncRunFunction = (
+  ...args: Parameters<RunFunction>
+) => Promise<ReturnType<RunFunction>>;
+
 export async function init(
   extraParams: ClingoParams = {}
 ): Promise<RunFunction> {

--- a/src/run.worker.ts
+++ b/src/run.worker.ts
@@ -1,5 +1,6 @@
 import type { RunFunction } from "./run";
 import { init } from "./run";
+import type { Witness } from "./witnesses";
 
 const clingoWasm = require("./clingo.wasm");
 const clingoMtWasm = require("./clingo-mt.wasm");
@@ -7,11 +8,21 @@ const clingoMtWasm = require("./clingo-mt.wasm");
 // from a real URL (this worker itself is an inline blob without one).
 const clingoMtJs = require("./clingo-mt.js?url");
 
+export type RunArgs = [program: string, models?: number, options?: string[]];
+
 export type Messages =
   | { type: "init"; wasmUrl?: string }
-  | { type: "run"; args: Parameters<RunFunction> };
+  | { type: "run"; args: RunArgs; stream?: boolean };
+
+export type Replies =
+  | { type: "model"; model: Witness }
+  | { type: "result"; result: ReturnType<RunFunction> | null };
 
 let run: RunFunction;
+
+function reply(message: Replies) {
+  postMessage(message, undefined as any);
+}
 
 async function initRun(wasmUrl?: string) {
   run = await init({
@@ -42,11 +53,15 @@ addEventListener("message", async (event) => {
     if (!run) {
       await initRun();
     }
-    const results = run(...message.args);
-    postMessage(results, undefined);
+    const [program, models, options] = message.args;
+    const onModel = message.stream
+      ? (model: Witness) => reply({ type: "model", model })
+      : undefined;
+    const result = run(program, models, options, onModel);
+    reply({ type: "result", result });
   } else if (message.type === "init") {
     await initRun(message.wasmUrl);
-    postMessage(null, undefined);
+    reply({ type: "result", result: null });
   }
 });
 

--- a/src/run.worker.ts
+++ b/src/run.worker.ts
@@ -21,7 +21,7 @@ export type Replies =
 let run: RunFunction;
 
 function reply(message: Replies) {
-  postMessage(message, undefined as any);
+  postMessage(message, undefined);
 }
 
 async function initRun(wasmUrl?: string) {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1,0 +1,42 @@
+import type { ClingoError, ClingoResult, RunFunction } from "./run";
+import type { Witness } from "./witnesses";
+
+/**
+ * Wraps a run function into an async generator that yields each model as it
+ * is found and returns the final result. In Node, solving blocks the event
+ * loop, so all models are yielded right after solving finishes; in the
+ * browser, solving runs in a worker and models arrive while it solves.
+ */
+export function makeStream(run: (...args: Parameters<RunFunction>) => Promise<ClingoResult | ClingoError>) {
+  return async function* stream(
+    program: string,
+    models: number = 1,
+    options: string[] = []
+  ): AsyncGenerator<Witness, ClingoResult | ClingoError> {
+    const queue: Witness[] = [];
+    let notify: (() => void) | undefined;
+    let final: ClingoResult | ClingoError | undefined;
+
+    const done = run(program, models, options, (model) => {
+      queue.push(model);
+      notify?.();
+    }).then((result) => {
+      final = result;
+      notify?.();
+      return result;
+    });
+
+    while (true) {
+      while (queue.length) {
+        yield queue.shift()!;
+      }
+      if (final !== undefined) {
+        break;
+      }
+      await new Promise<void>((resolve) => (notify = resolve));
+      notify = undefined;
+    }
+
+    return done;
+  };
+}

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1,4 +1,4 @@
-import type { ClingoError, ClingoResult, RunFunction } from "./run";
+import type { AsyncRunFunction, ClingoError, ClingoResult } from "./run";
 import type { Witness } from "./witnesses";
 
 /**
@@ -7,36 +7,32 @@ import type { Witness } from "./witnesses";
  * loop, so all models are yielded right after solving finishes; in the
  * browser, solving runs in a worker and models arrive while it solves.
  */
-export function makeStream(run: (...args: Parameters<RunFunction>) => Promise<ClingoResult | ClingoError>) {
+export function makeStream(run: AsyncRunFunction) {
   return async function* stream(
     program: string,
     models: number = 1,
     options: string[] = []
   ): AsyncGenerator<Witness, ClingoResult | ClingoError> {
     const queue: Witness[] = [];
-    let notify: (() => void) | undefined;
+    let wake = () => {};
     let final: ClingoResult | ClingoError | undefined;
 
-    const done = run(program, models, options, (model) => {
+    run(program, models, options, (model) => {
       queue.push(model);
-      notify?.();
+      wake();
     }).then((result) => {
       final = result;
-      notify?.();
-      return result;
+      wake();
     });
 
-    while (true) {
-      while (queue.length) {
+    while (final === undefined || queue.length > 0) {
+      if (queue.length > 0) {
         yield queue.shift()!;
+      } else {
+        await new Promise<void>((resolve) => (wake = resolve));
       }
-      if (final !== undefined) {
-        break;
-      }
-      await new Promise<void>((resolve) => (notify = resolve));
-      notify = undefined;
     }
 
-    return done;
+    return final;
   };
 }

--- a/src/witnesses.ts
+++ b/src/witnesses.ts
@@ -1,0 +1,85 @@
+/** A single model (witness) from clingo's JSON output. */
+export interface Witness {
+  Value: string[];
+  Time?: number;
+  Costs?: number[];
+  Consequences?: any;
+}
+
+/**
+ * Incrementally extracts witnesses from the JSON that clingo streams to
+ * stdout with --outf=2, so models can be reported while solving is still
+ * running. Tracks JSON string and nesting state character by character, so it
+ * does not depend on the pretty-printer's indentation or on atom contents.
+ */
+export class WitnessParser {
+  private inWitnesses = false;
+  private inString = false;
+  private escaped = false;
+  private depth = 0;
+  private buffer = "";
+
+  constructor(private onWitness: (witness: Witness) => void) {}
+
+  feed(line: string) {
+    if (!this.inWitnesses) {
+      if (line.trim() === '"Witnesses": [') {
+        this.inWitnesses = true;
+      }
+      return;
+    }
+
+    for (const char of line) {
+      if (this.inString) {
+        if (this.buffer) {
+          this.buffer += char;
+        }
+        if (this.escaped) {
+          this.escaped = false;
+        } else if (char === "\\") {
+          this.escaped = true;
+        } else if (char === '"') {
+          this.inString = false;
+        }
+        continue;
+      }
+
+      switch (char) {
+        case '"':
+          this.inString = true;
+          if (this.buffer) {
+            this.buffer += char;
+          }
+          break;
+        case "{":
+          this.depth++;
+          this.buffer += char;
+          break;
+        case "}":
+          this.depth--;
+          this.buffer += char;
+          if (this.depth === 0) {
+            this.onWitness(JSON.parse(this.buffer));
+            this.buffer = "";
+          }
+          break;
+        case "]":
+          if (this.depth === 0) {
+            // end of the Witnesses array
+            this.inWitnesses = false;
+            return;
+          }
+          this.buffer += char;
+          break;
+        default:
+          if (this.buffer) {
+            this.buffer += char;
+          }
+      }
+    }
+
+    if (this.buffer) {
+      this.buffer += "\n";
+    }
+  }
+}

--- a/src/witnesses.ts
+++ b/src/witnesses.ts
@@ -9,59 +9,82 @@ export interface Witness {
 /**
  * Incrementally extracts witnesses from the JSON that clingo streams to
  * stdout with --outf=2, so models can be reported while solving is still
- * running. Witness objects are found by tracking brace depth inside the
- * "Witnesses" array; JSON strings are skipped over character by character, so
- * the parser does not depend on the pretty-printer's indentation or on atom
- * contents.
+ * running.
+ *
+ * The parser tracks strings (honoring escapes) and the stack of containers
+ * with the key each one was entered under. A witness is any object that is a
+ * direct element of an array behind a "Witnesses" key; its text is captured
+ * and parsed when the object closes. This only assumes the output is valid
+ * JSON with the witnesses in "Witnesses" arrays; it is independent of
+ * formatting, and atom contents cannot confuse it since structural characters
+ * are only interpreted outside of strings.
  */
 export class WitnessParser {
-  private inWitnesses = false;
-  private capturing = false;
+  /** Containers entered so far, each with the key it was entered under. */
+  private stack: { container: "{" | "["; key?: string }[] = [];
+  /** The key that the next value in the current object belongs to. */
+  private pendingKey?: string;
   private inString = false;
   private escaped = false;
-  private depth = 0;
+  private string = "";
+  /** Stack depth at which the currently captured witness started. */
+  private captureDepth = 0;
   private buffer = "";
 
   constructor(private onWitness: (witness: Witness) => void) {}
 
-  feed(line: string) {
-    if (!this.inWitnesses) {
-      this.inWitnesses = line.trim() === '"Witnesses": [';
-      return;
-    }
-
-    for (const char of line) {
-      if (this.capturing) {
+  feed(chunk: string) {
+    for (const char of chunk) {
+      if (this.captureDepth > 0) {
         this.buffer += char;
       }
 
       if (this.inString) {
-        // only look for the end of the string, honoring escapes
         if (this.escaped) {
           this.escaped = false;
         } else if (char === "\\") {
           this.escaped = true;
         } else if (char === '"') {
           this.inString = false;
+        } else {
+          this.string += char;
         }
-      } else if (char === '"') {
-        this.inString = true;
-      } else if (char === "{") {
-        if (!this.capturing) {
-          // a new witness begins
-          this.capturing = true;
-          this.buffer = char;
+        continue;
+      }
+
+      switch (char) {
+        case '"':
+          this.inString = true;
+          this.string = "";
+          break;
+        case ":":
+          this.pendingKey = this.string;
+          break;
+        case "{":
+        case "[": {
+          const parent = this.stack[this.stack.length - 1];
+          const key =
+            parent?.container === "{" ? this.pendingKey : undefined;
+          this.stack.push({ container: char, key });
+          if (
+            char === "{" &&
+            this.captureDepth === 0 &&
+            parent?.container === "[" &&
+            parent.key === "Witnesses"
+          ) {
+            this.captureDepth = this.stack.length;
+            this.buffer = char;
+          }
+          break;
         }
-        this.depth++;
-      } else if (char === "}") {
-        if (--this.depth === 0) {
-          this.onWitness(JSON.parse(this.buffer));
-          this.capturing = false;
-        }
-      } else if (char === "]" && this.depth === 0) {
-        // the Witnesses array ends
-        this.inWitnesses = false;
-        return;
+        case "}":
+        case "]":
+          if (this.captureDepth === this.stack.length) {
+            this.onWitness(JSON.parse(this.buffer));
+            this.captureDepth = 0;
+          }
+          this.stack.pop();
+          break;
       }
     }
   }

--- a/src/witnesses.ts
+++ b/src/witnesses.ts
@@ -9,11 +9,14 @@ export interface Witness {
 /**
  * Incrementally extracts witnesses from the JSON that clingo streams to
  * stdout with --outf=2, so models can be reported while solving is still
- * running. Tracks JSON string and nesting state character by character, so it
- * does not depend on the pretty-printer's indentation or on atom contents.
+ * running. Witness objects are found by tracking brace depth inside the
+ * "Witnesses" array; JSON strings are skipped over character by character, so
+ * the parser does not depend on the pretty-printer's indentation or on atom
+ * contents.
  */
 export class WitnessParser {
   private inWitnesses = false;
+  private capturing = false;
   private inString = false;
   private escaped = false;
   private depth = 0;
@@ -23,17 +26,17 @@ export class WitnessParser {
 
   feed(line: string) {
     if (!this.inWitnesses) {
-      if (line.trim() === '"Witnesses": [') {
-        this.inWitnesses = true;
-      }
+      this.inWitnesses = line.trim() === '"Witnesses": [';
       return;
     }
 
     for (const char of line) {
+      if (this.capturing) {
+        this.buffer += char;
+      }
+
       if (this.inString) {
-        if (this.buffer) {
-          this.buffer += char;
-        }
+        // only look for the end of the string, honoring escapes
         if (this.escaped) {
           this.escaped = false;
         } else if (char === "\\") {
@@ -41,45 +44,25 @@ export class WitnessParser {
         } else if (char === '"') {
           this.inString = false;
         }
-        continue;
+      } else if (char === '"') {
+        this.inString = true;
+      } else if (char === "{") {
+        if (!this.capturing) {
+          // a new witness begins
+          this.capturing = true;
+          this.buffer = char;
+        }
+        this.depth++;
+      } else if (char === "}") {
+        if (--this.depth === 0) {
+          this.onWitness(JSON.parse(this.buffer));
+          this.capturing = false;
+        }
+      } else if (char === "]" && this.depth === 0) {
+        // the Witnesses array ends
+        this.inWitnesses = false;
+        return;
       }
-
-      switch (char) {
-        case '"':
-          this.inString = true;
-          if (this.buffer) {
-            this.buffer += char;
-          }
-          break;
-        case "{":
-          this.depth++;
-          this.buffer += char;
-          break;
-        case "}":
-          this.depth--;
-          this.buffer += char;
-          if (this.depth === 0) {
-            this.onWitness(JSON.parse(this.buffer));
-            this.buffer = "";
-          }
-          break;
-        case "]":
-          if (this.depth === 0) {
-            // end of the Witnesses array
-            this.inWitnesses = false;
-            return;
-          }
-          this.buffer += char;
-          break;
-        default:
-          if (this.buffer) {
-            this.buffer += char;
-          }
-      }
-    }
-
-    if (this.buffer) {
-      this.buffer += "\n";
     }
   }
 }

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,4 +1,4 @@
-import { ClingoResult, run } from "../src/index.node";
+import { ClingoResult, Witness, run, stream } from "../src/index.node";
 import { ClingoError } from "../src/run";
 
 // uncomment to test compiled file
@@ -90,6 +90,40 @@ describe("run", () => {
       ["-t 4"]
     )) as ClingoResult;
     expect(Result).toBe("UNSATISFIABLE");
+  });
+
+  it("should report models to the onModel callback", async () => {
+    const streamed: Witness[] = [];
+    const { Call } = (await run("{a; b; c}.", 0, [], (model) =>
+      streamed.push(model)
+    )) as ClingoResult;
+    expect(streamed).toHaveLength(8);
+    expect(streamed).toEqual(Call[0].Witnesses);
+  });
+
+  it("should stream models with costs", async () => {
+    const streamed: Witness[] = [];
+    const result = (await run(
+      "{a; b}. #minimize {1:a}.",
+      0,
+      ["--opt-mode=optN"],
+      (model) => streamed.push(model)
+    )) as ClingoResult;
+    expect(result.Result).toBe("OPTIMUM FOUND");
+    expect(streamed.length).toBeGreaterThan(0);
+    expect(streamed[streamed.length - 1].Costs).toEqual([0]);
+  });
+
+  it("should support async iteration over models", async () => {
+    const streamed: Witness[] = [];
+    const generator = stream("{a; b; c}.", 0);
+    let next = await generator.next();
+    while (!next.done) {
+      streamed.push(next.value);
+      next = await generator.next();
+    }
+    expect(streamed).toHaveLength(8);
+    expect((next.value as ClingoResult).Result).toBe("SATISFIABLE");
   });
 
   it("should keep working after an error", async () => {

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,5 +1,6 @@
 import { ClingoResult, Witness, run, stream } from "../src/index.node";
 import { ClingoError } from "../src/run";
+import { WitnessParser } from "../src/witnesses";
 
 // uncomment to test compiled file
 // import run from "../dist/clingo.node";
@@ -126,11 +127,73 @@ describe("run", () => {
     expect((next.value as ClingoResult).Result).toBe("SATISFIABLE");
   });
 
+  it("should stream models with adversarial atom contents", async () => {
+    // strings with quotes, braces, backslashes, unicode, and text that looks
+    // like the JSON structure the parser searches for
+    const program =
+      'a("{"). b("\\""). c("[Witnesses]"). d("\\\\"). e("日本語 }],"). ' +
+      'f("\\"Witnesses\\": [").';
+    const streamed: Witness[] = [];
+    const { Call } = (await run(program, 0, [], (model) =>
+      streamed.push(model)
+    )) as ClingoResult;
+    expect(streamed).toHaveLength(1);
+    expect(streamed).toEqual(Call[0].Witnesses);
+    expect(streamed[0].Value).toHaveLength(6);
+  });
+
   it("should keep working after an error", async () => {
     const error = (await run("this is invalid")) as ClingoError;
     expect(error.Result).toBe("ERROR");
 
     const { Result } = (await run("a.")) as ClingoResult;
     expect(Result).toBe("SATISFIABLE");
+  });
+});
+
+describe("WitnessParser", () => {
+  const document = JSON.stringify(
+    {
+      Solver: "clingo version 5.8.1",
+      Call: [
+        {
+          Witnesses: [
+            { Time: 0.1, Value: ['tricky("{[\\"Witnesses\\": [")', "a"] },
+            {
+              Time: 0.2,
+              Value: [],
+              Costs: [0],
+              Consequences: { True: 3, Open: 0 },
+            },
+          ],
+        },
+      ],
+      Result: "SATISFIABLE",
+    },
+    null,
+    2
+  );
+  const expected = [
+    { Time: 0.1, Value: ['tricky("{[\\"Witnesses\\": [")', "a"] },
+    { Time: 0.2, Value: [], Costs: [0], Consequences: { True: 3, Open: 0 } },
+  ];
+
+  it("should extract witnesses from pretty-printed output", () => {
+    const witnesses: Witness[] = [];
+    const parser = new WitnessParser((witness) => witnesses.push(witness));
+    for (const line of document.split("\n")) {
+      parser.feed(line);
+    }
+    expect(witnesses).toEqual(expected);
+  });
+
+  it("should not depend on chunking or formatting", () => {
+    const witnesses: Witness[] = [];
+    const parser = new WitnessParser((witness) => witnesses.push(witness));
+    // compact document fed one character at a time
+    for (const char of JSON.stringify(JSON.parse(document))) {
+      parser.feed(char);
+    }
+    expect(witnesses).toEqual(expected);
   });
 });


### PR DESCRIPTION
Models can now be observed as clingo finds them instead of only after solving finishes:

```js
// callback
await clingo.run("{a; b; c}.", 0, [], (model) => console.log(model.Value));

// or async iteration
for await (const model of clingo.stream("{a; b; c}.", 0)) {
  console.log(model.Value);
}
```

**How it works**

- Clingo already writes its `--outf=2` JSON incrementally during solving (measured: enumerating all 352 solutions of 9-queens, witness lines arrive spread across the whole solve). A structural incremental parser (`src/witnesses.ts`) extracts each witness as its object completes: it tracks JSON strings (honoring escapes), the container stack, and the key each container was entered under, and captures objects that are elements of an array behind a `"Witnesses"` key. Its only assumptions are that the output is valid JSON and where witnesses live in it — indentation, line breaks, chunk boundaries, and atom contents cannot confuse it. A parser failure disables streaming for the run instead of failing it.
- `run()` gains an optional `onModel` callback. In the browser, the worker posts each model to the main thread while the (blocked) solve continues; `stream()` wraps that into an async generator that yields models and returns the final result.
- In Node, solving blocks the event loop: the callback fires during the run, while generator consumers see the models once solving finishes (documented in the README).
- The gh-pages demo now updates its output as models are found instead of only at the end.
- No changes to the wasm build — this is JS-only, so no CI rebuild cycle. (A streaming-JSON dependency was considered and prototyped, but the maintained option would add ~15 KB minified to each bundle while only replacing the tokenizer half of ~90 lines of dependency-free code.)

**Verified**

- 13/13 jest tests, including: streamed models exactly match the final result's witnesses; costs stream during optimization; async iteration terminates with the final result; adversarial atoms (quotes, braces, backslashes, unicode, and text mimicking `"Witnesses": [`) stream correctly through real clingo; and parser unit tests with pretty-printed line feeding and compact character-by-character feeding.
- Chromium: 352/352 models streamed for 9-queens with the first model arriving on the main thread at ~170ms while solving ran to ~270ms — genuinely incremental; threaded/parallel scenarios unaffected.

Closes #34